### PR TITLE
Specify Cabal-Version in cabal file

### DIFF
--- a/data-checked.cabal
+++ b/data-checked.cabal
@@ -1,5 +1,6 @@
 Name: data-checked
 Version: 0.3
+Cabal-Version: >= 1.8
 Category: Data
 Stability: experimental
 Synopsis: Type-indexed runtime-checked properties 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: data-checked.cabal:27:30: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```